### PR TITLE
Warnsdorff’s algorithm for Knight’s tour problem

### DIFF
--- a/Warnsdorff’s algorithm_for_Knight’s_tour_problem
+++ b/Warnsdorff’s algorithm_for_Knight’s_tour_problem
@@ -1,0 +1,149 @@
+// C++ program to for Kinight's tour problem usin 
+// Warnsdorff's algorithm 
+#include <bits/stdc++.h> 
+#define N 8 
+  
+// Move pattern on basis of the change of 
+// x coordinates and y coordinates respectively 
+static int cx[N] = {1,1,2,2,-1,-1,-2,-2}; 
+static int cy[N] = {2,-2,1,-1,2,-2,1,-1}; 
+  
+// function restricts the knight to remain within 
+// the 8x8 chessboard 
+bool limits(int x, int y) 
+{ 
+    return ((x >= 0 && y >= 0) && (x < N && y < N)); 
+} 
+  
+/* Checks whether a square is valid and empty or not */
+bool isempty(int a[], int x, int y) 
+{ 
+    return (limits(x, y)) && (a[y*N+x] < 0); 
+} 
+  
+/* Returns the number of empty squares adjacent 
+   to (x, y) */
+int getDegree(int a[], int x, int y) 
+{ 
+    int count = 0; 
+    for (int i = 0; i < N; ++i) 
+        if (isempty(a, (x + cx[i]), (y + cy[i]))) 
+            count++; 
+  
+    return count; 
+} 
+  
+// Picks next point using Warnsdorff's heuristic. 
+// Returns false if it is not possible to pick 
+// next point. 
+bool nextMove(int a[], int *x, int *y) 
+{ 
+    int min_deg_idx = -1, c, min_deg = (N+1), nx, ny; 
+  
+    // Try all N adjacent of (*x, *y) starting 
+    // from a random adjacent. Find the adjacent 
+    // with minimum degree. 
+    int start = rand()%N; 
+    for (int count = 0; count < N; ++count) 
+    { 
+        int i = (start + count)%N; 
+        nx = *x + cx[i]; 
+        ny = *y + cy[i]; 
+        if ((isempty(a, nx, ny)) && 
+           (c = getDegree(a, nx, ny)) < min_deg) 
+        { 
+            min_deg_idx = i; 
+            min_deg = c; 
+        } 
+    } 
+  
+    // IF we could not find a next cell 
+    if (min_deg_idx == -1) 
+        return false; 
+  
+    // Store coordinates of next point 
+    nx = *x + cx[min_deg_idx]; 
+    ny = *y + cy[min_deg_idx]; 
+  
+    // Mark next move 
+    a[ny*N + nx] = a[(*y)*N + (*x)]+1; 
+  
+    // Update next point 
+    *x = nx; 
+    *y = ny; 
+  
+    return true; 
+} 
+  
+/* displays the chessboard with all the 
+  legal knight's moves */
+void print(int a[]) 
+{ 
+    for (int i = 0; i < N; ++i) 
+    { 
+        for (int j = 0; j < N; ++j) 
+            printf("%d\t",a[j*N+i]); 
+        printf("\n"); 
+    } 
+} 
+  
+/* checks its neighbouring sqaures */
+/* If the knight ends on a square that is one 
+   knight's move from the beginning square, 
+   then tour is closed */
+bool neighbour(int x, int y, int xx, int yy) 
+{ 
+    for (int i = 0; i < N; ++i) 
+        if (((x+cx[i]) == xx)&&((y + cy[i]) == yy)) 
+            return true; 
+  
+    return false; 
+} 
+  
+/* Generates the legal moves using warnsdorff's 
+  heuristics. Returns false if not possible */
+bool findClosedTour() 
+{ 
+    // Filling up the chessboard matrix with -1's 
+    int a[N*N]; 
+    for (int i = 0; i< N*N; ++i) 
+        a[i] = -1; 
+  
+    // Randome initial position 
+    int sx = rand()%N; 
+    int sy = rand()%N; 
+  
+    // Current points are same as initial points 
+    int x = sx, y = sy; 
+    a[y*N+x] = 1; // Mark first move. 
+  
+    // Keep picking next points using 
+    // Warnsdorff's heuristic 
+    for (int i = 0; i < N*N-1; ++i) 
+        if (nextMove(a, &x, &y) == 0) 
+            return false; 
+  
+    // Check if tour is closed (Can end 
+    // at starting point) 
+    if (!neighbour(x, y, sx, sy)) 
+        return false; 
+  
+    print(a); 
+    return true; 
+} 
+  
+// Driver code 
+int main() 
+{ 
+    // To make sure that different random 
+    // initial positions are picked. 
+    srand(time(NULL)); 
+  
+    // While we don't get a solution 
+    while (!findClosedTour()) 
+    { 
+    ; 
+    } 
+  
+    return 0; 
+} 


### PR DESCRIPTION
Problem : A knight is placed on the first block of an empty board and, moving according to the rules of chess, must visit each square exactly once.

Following is an example path followed by Knight to cover all the cells. The below grid represents a chessboard with 8 x 8 cells. Numbers in cells indicate move number of Knight.

Warnsdorff’s Rule:

We can start from any initial position of the knight on the board.
We always move to an adjacent, unvisited square with minimal degree (minimum number of unvisited adjacent).
This algorithm may also more generally be applied to any graph.

Some definitions:

A position Q is accessible from a position P if P can move to Q by a single Knight’s move, and Q has not yet been visited.
The accessibility of a position P is the number of positions accessible from P.
Algorithm:

Set P to be a random initial position on the board
Mark the board at P with the move number “1”
Do following for each move number from 2 to the number of squares on the board:
let S be the set of positions accessible from P.
Set P to be the position in S with minimum accessibility
Mark the board at P with the current move number
Return the marked board — each square will be marked with the move number on which it is visited.